### PR TITLE
security: stop handing the whole secrets context to the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,28 @@ jobs:
     needs: determine-environment
     runs-on: self-hosted
     environment: ${{ needs.determine-environment.outputs.environment }}
+    # Only the secrets .kamal/secrets-common actually references. This job
+    # previously serialised the entire secrets context into one variable and
+    # picked through it at runtime, which handed every repository and
+    # environment secret to the job and wrote them all to a file on the
+    # self-hosted runner.
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
+      DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+      DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
+      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+      DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
+      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
+      RACK_ATTACK_REDIS_URL: ${{ secrets.RACK_ATTACK_REDIS_URL }}
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+      SIDEKIQ_REDIS_URL: ${{ secrets.SIDEKIQ_REDIS_URL }}
     steps:
       - name: Set workflow start time
         run: |
@@ -57,64 +79,11 @@ jobs:
           runner-name: ${{ runner.name }}
           start-time: ${{ env.START_TIME }}
 
-      - name: Export and validate kamal secrets
-        shell: bash
-        env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
-          KAMAL_SECRETS_FILE: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
-        run: |
-          if [[ -z "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: kamal secrets file path not provided."
-            exit 1
-          fi
-          if [[ ! -f "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: $KAMAL_SECRETS_FILE file not found."
-            exit 1
-          fi
-
-          temp_secrets="$(mktemp)"
-          trap 'rm -f "$temp_secrets"' EXIT
-          printf '%s' "$SECRETS_JSON" > "$temp_secrets"
-
-          needed_vars=()
-          while IFS= read -r line; do
-            trimmed="$(echo "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-            [[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
-            [[ "$trimmed" != *=* ]] && continue
-
-            value="${trimmed#*=}"
-            value="${value#"${value%%[![:space:]]*}"}"
-            value="${value%"${value##*[![:space:]]}"}"
-
-            [[ "$value" != \$* ]] && continue
-            [[ "$value" == '$('* ]] && continue
-
-            if [[ "$value" == \$\{* ]]; then
-              if [[ "$value" =~ ^\$\{([A-Z0-9_]+) ]]; then
-                needed_vars+=("${BASH_REMATCH[1]}")
-              fi
-            elif [[ "$value" =~ ^\$([A-Z0-9_]+) ]]; then
-              needed_vars+=("${BASH_REMATCH[1]}")
-            fi
-          done < "$KAMAL_SECRETS_FILE"
-
-          IFS=$'\n' read -r -d '' -a unique_vars < <(printf '%s\n' "${needed_vars[@]}" | sort -u && printf '\0')
-
-          for var in "${unique_vars[@]}"; do
-            value=$(jq -r --arg key "$var" '.[$key] // empty' "$temp_secrets")
-            if [[ -z "$value" ]]; then
-              echo "Missing environment variable required in .kamal/secrets-common: ${var}" >&2
-              exit 1
-            fi
-
-            {
-              echo "${var}<<EOF"
-              echo "$value"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
-          done
-
-          echo "✅ All required kamal secrets are validated and available as environment variables"
+      - name: Validate kamal secrets
+        uses: unepwcmc/devops-actions/.github/actions/validate-secrets@v1
+        with:
+          secrets-file: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
+          environment: ${{ needs.determine-environment.outputs.environment }}
 
       - name: Deploy with Kamal v2
         uses: unepwcmc/devops-actions/.github/actions/kamal-v2.x-deploy@v1
@@ -123,8 +92,6 @@ jobs:
           working-directory: .
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
-          PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
 
       - name: Set workflow end time and calculate duration
         if: always()


### PR DESCRIPTION
Found while auditing the deploy actions. Not urgent, but worth closing.

## What

The deploy job does this:

```yaml
env:
  SECRETS_JSON: ${{ toJSON(secrets) }}
```

then writes it to a temp file on the runner and greps out the variables `.kamal/secrets-common` references:

```bash
temp_secrets="$(mktemp)"
printf '%s' "$SECRETS_JSON" > "$temp_secrets"
```

Two issues:

1. **Scope.** The job receives every repository and environment secret, not the 16 it needs.
2. **Disk.** All of them land together in one file on a **self-hosted** runner. `mktemp` is `0600`, but self-hosted runners generally execute every job as the same OS user, so a concurrent job from any other repo can read it while it exists. The `trap` cleans up on exit but not if the runner is killed mid-job.

There is also a decent chance this is what trips GitHub's "this workflow file may be malicious" gate — serialising the whole secrets context is the shape that detection looks for. Run 31099132713 was blocked that way on 6 Aug and needed manual approval. I cannot prove that is the rule, and enforcement was inconsistent, so treat it as a bonus rather than the reason.

## Change

An explicit job-level `env:` block listing exactly the 16 variables `secrets-common` references, and the existing `validate-secrets` action in place of the inline parser.

`validate-secrets` reads the same `secrets-common`, checks each variable is non-empty, and fails with `::error::Missing required secret: NAME`. So drift between `secrets-common` and the configured secrets is still caught at deploy time, with a clearer message than before.

## Checked

The 16 variables map 1:1 onto the 16 staging environment secrets, and the same 16 exist in production. Nothing needs adding or renaming.

```
AWS_ACCESS_KEY_ID  AWS_REGION  AWS_SECRET_ACCESS_KEY  CERTIFICATE_PEM
DATABASE_HOST  DATABASE_NAME  DATABASE_PASSWORD  DATABASE_PORT
DATABASE_USERNAME  MAIL_PASSWORD  MAIL_USERNAME  PRIVATE_KEY_PEM
RACK_ATTACK_REDIS_URL  RAILS_MASTER_KEY  REDIS_CACHE_URL  SIDEKIQ_REDIS_URL
```

`CERTIFICATE_PEM` and `PRIVATE_KEY_PEM` were also set step-level on the deploy step; they now come from the job env, so those two lines are dropped. `SSH_PRIVATE_KEY` stays step-level — it is a repo secret the deploy action needs and is not in `secrets-common`.

## Testing

Merging pushes to `staging`, which deploys. Worth watching that run — if `validate-secrets` reports all 16 green and Kamal deploys, the remaining 10 repos can follow the same shape.