### PR TITLE
chore: bump actions/checkout to v5 for the node24 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           echo "START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
           echo "ACTION_TYPE=Deploy" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Notify deployment start
         id: notify-start


### PR DESCRIPTION
Follow-on to #53 — this commit landed on the branch just after that PR merged, so it needs its own.

`actions/checkout@v4` targets node20, which runners now force onto node24 with a deprecation warning. v5 declares node24 natively.

This is the last node20 pin reaching this workflow. `devops-actions` moved `slack-github-action` v1.26.0 → v4 in `b408cc4`, so with this merged the next staging run should report no Node deprecation warnings at all.

Warnings on the last run (31104725522):

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/checkout@v4,
slackapi/slack-github-action@v1.26.0
```

Merging deploys to staging. Worth watching that the two Slack notifications still post and thread correctly — the v4 rewrite changes how the payload is assembled (channel and ts move into the payload, `chat.postMessage` vs `chat.update` selects the method), so this run is also the first live exercise of that.