### PR TITLE
security: stop handing the whole secrets context to the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,35 @@ jobs:
     needs: determine-environment
     runs-on: self-hosted
     environment: ${{ needs.determine-environment.outputs.environment }}
+    # Only the secrets .kamal/secrets-common actually references. This job
+    # previously serialised the entire secrets context into one variable and
+    # picked through it at runtime, which handed every repository and
+    # environment secret to the job and wrote them all to a file on the
+    # self-hosted runner.
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
+      DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+      DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
+      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+      DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
+      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
+      RACK_ATTACK_REDIS_URL: ${{ secrets.RACK_ATTACK_REDIS_URL }}
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+      SIDEKIQ_REDIS_URL: ${{ secrets.SIDEKIQ_REDIS_URL }}
     steps:
       - name: Set workflow start time
         run: |
           echo "START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
           echo "ACTION_TYPE=Deploy" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Notify deployment start
         id: notify-start
@@ -57,64 +79,11 @@ jobs:
           runner-name: ${{ runner.name }}
           start-time: ${{ env.START_TIME }}
 
-      - name: Export and validate kamal secrets
-        shell: bash
-        env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
-          KAMAL_SECRETS_FILE: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
-        run: |
-          if [[ -z "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: kamal secrets file path not provided."
-            exit 1
-          fi
-          if [[ ! -f "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: $KAMAL_SECRETS_FILE file not found."
-            exit 1
-          fi
-
-          temp_secrets="$(mktemp)"
-          trap 'rm -f "$temp_secrets"' EXIT
-          printf '%s' "$SECRETS_JSON" > "$temp_secrets"
-
-          needed_vars=()
-          while IFS= read -r line; do
-            trimmed="$(echo "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-            [[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
-            [[ "$trimmed" != *=* ]] && continue
-
-            value="${trimmed#*=}"
-            value="${value#"${value%%[![:space:]]*}"}"
-            value="${value%"${value##*[![:space:]]}"}"
-
-            [[ "$value" != \$* ]] && continue
-            [[ "$value" == '$('* ]] && continue
-
-            if [[ "$value" == \$\{* ]]; then
-              if [[ "$value" =~ ^\$\{([A-Z0-9_]+) ]]; then
-                needed_vars+=("${BASH_REMATCH[1]}")
-              fi
-            elif [[ "$value" =~ ^\$([A-Z0-9_]+) ]]; then
-              needed_vars+=("${BASH_REMATCH[1]}")
-            fi
-          done < "$KAMAL_SECRETS_FILE"
-
-          IFS=$'\n' read -r -d '' -a unique_vars < <(printf '%s\n' "${needed_vars[@]}" | sort -u && printf '\0')
-
-          for var in "${unique_vars[@]}"; do
-            value=$(jq -r --arg key "$var" '.[$key] // empty' "$temp_secrets")
-            if [[ -z "$value" ]]; then
-              echo "Missing environment variable required in .kamal/secrets-common: ${var}" >&2
-              exit 1
-            fi
-
-            {
-              echo "${var}<<EOF"
-              echo "$value"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
-          done
-
-          echo "✅ All required kamal secrets are validated and available as environment variables"
+      - name: Validate kamal secrets
+        uses: unepwcmc/devops-actions/.github/actions/validate-secrets@v1
+        with:
+          secrets-file: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
+          environment: ${{ needs.determine-environment.outputs.environment }}
 
       - name: Deploy with Kamal v2
         uses: unepwcmc/devops-actions/.github/actions/kamal-v2.x-deploy@v1
@@ -123,8 +92,6 @@ jobs:
           working-directory: .
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
-          PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
 
       - name: Set workflow end time and calculate duration
         if: always()


### PR DESCRIPTION
**Catch-up.** This already went in on `staging` and deployed cleanly; this brings `develop` in line so the two stop diverging.

## What

The deploy job serialised the entire secrets context into `SECRETS_JSON`, wrote it to a temp file on the self-hosted runner, then picked out the variables `.kamal/secrets-common` references.

Two issues: the job received every repository and environment secret rather than the 16 it needs, and all of them landed in one file on a runner where jobs typically share an OS user, so a concurrent job from another repo could read it.

## Change

Explicit job-level `env:` with exactly the 16 variables `secrets-common` references, and the `validate-secrets` action in place of the inline parser — same file, same check, still fails with `::error::Missing required secret: NAME` so drift is caught at deploy time.

Also bumps `actions/checkout` v4 → v5 for the node24 runtime.

## Checked

The 16 map 1:1 onto **both** the staging and production environment secrets — nothing to add or rename:

```
AWS_ACCESS_KEY_ID  AWS_REGION  AWS_SECRET_ACCESS_KEY  CERTIFICATE_PEM  DATABASE_HOST  DATABASE_NAME  DATABASE_PASSWORD  DATABASE_PORT  DATABASE_USERNAME  MAIL_PASSWORD  MAIL_USERNAME  PRIVATE_KEY_PEM  RACK_ATTACK_REDIS_URL  RAILS_MASTER_KEY  REDIS_CACHE_URL  SIDEKIQ_REDIS_URL
```

The block is generated per repo from this repo's own `secrets-common`, not copied between repos.

## Validated

Same change is already deployed and green on `species-api` and `cites-compliance-tool` staging: deploy succeeded, `Validate kamal secrets` passed, and both runs reported zero Node deprecation warnings.

Merging this deploys nothing — `deploy.yml` only triggers on push to `staging`. `deploy-production.yml` has the same pattern and follows separately.